### PR TITLE
Adding new type of output - Javascript Object

### DIFF
--- a/js/DataGridRenderer.js
+++ b/js/DataGridRenderer.js
@@ -122,14 +122,14 @@ var DataGridRenderer = {
   
   
   //---------------------------------------
-  // JSON properties
+  // Javascript Object
   //---------------------------------------
   
   json: function (dataGrid, headerNames, headerTypes, indent, newLine) {
     //inits...
     var commentLine = "//";
     var commentLineEnd = "";
-    var outputText = "[";
+    var outputText = "var mrDataConverterObj = JSON.parse('[";
     var numRows = dataGrid.length;
     var numColumns = headerNames.length;
     
@@ -149,9 +149,9 @@ var DataGridRenderer = {
         if (j < (numColumns-1)) {outputText+=","};
       };
       outputText += "}";
-      if (i < (numRows-1)) {outputText += ","+newLine};
+      if (i < (numRows-1)) {outputText += ","};
     };
-    outputText += "]";
+    outputText += "]')";
     
     return outputText;
   },


### PR DESCRIPTION
I love the fact that the MySQL output can be pasted into SQL editor. I needed the same thing for pasting into Javascript editor when dealing with really large spreadsheets. These changes will allow users to paste the data output straight into their Javascript editor; providing all of the benefits of working with a native Javascript object (and all of its properties). 
The code changes in this commit are simply the addition of native instantiation of a Javascript object named mrDataConverterObj, the removal of the newline character (after each record) and enclosing the entire output with single quotes (as you would do if you wanted to parse the output as a JSON object in Javascript).